### PR TITLE
Replace Underscores in Emoji Names

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -97,10 +97,12 @@ class GenerateCommand extends Command
         $tags = implode(' ', $emoji['tags']);
         $description = $this->emojiToNames[$emojiCharacter];
 
+        $names = str_replace('_', ' ', $names);
+
         return (new Snippet(
             snippet: $emojiCharacter,
             uuid: $uuid,
-            name: "{$emojiCharacter} {$names}" . ($tags) ?: "- {$tags}",
+            name: "{$emojiCharacter} {$names} {$tags}",
             keyword: ":{$description}:",
         ))->toArray();
     }

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -3,9 +3,6 @@
 namespace Wnx\AlfredEmojiPack\Console;
 
 use DirectoryIterator;
-use JetBrains\PhpStorm\Pure;
-use Ramsey\Uuid\Lazy\LazyUuidFromString;
-use Ramsey\Uuid\Uuid;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;


### PR DESCRIPTION
This PR replaces the underscores in names.

- Before: `🤯 exploding_head mind blown`
- After: `🤯 exploding head mind blown`

*Also adds a space between $names and $tags*